### PR TITLE
Add intelligent local/live query API, new CLI commands (define, relat…

### DIFF
--- a/slb_glossary/__init__.py
+++ b/slb_glossary/__init__.py
@@ -18,7 +18,7 @@ above. See `slb_glossary.paths` and `slb_glossary.local` for details.
 
 import logging
 
-from . import local, store
+from . import local, query, store
 from .browser import (
     BrowserType,
     ResourceType,
@@ -37,6 +37,7 @@ from .errors import (
     GlossaryError,
     NetworkError,
     ParsingError,
+    QueryError,
 )
 from .models import Language, SearchResult, SearchSession
 from .retries import BackoffType, RetryPolicy
@@ -51,6 +52,7 @@ __version__ = "0.1.0"
 __all__ = [
     "store",
     "local",
+    "query",
     "open_session",
     "open_session_from_config",
     "close_session",
@@ -76,6 +78,7 @@ __all__ = [
     "ParsingError",
     "ConfigError",
     "DatabaseError",
+    "QueryError",
     "BrowserType",
     "ResourceType",
 ]

--- a/slb_glossary/cli/commands/__init__.py
+++ b/slb_glossary/cli/commands/__init__.py
@@ -1,9 +1,30 @@
 """Individual command implementations wired into `slb_glossary.cli.main`."""
 
+from slb_glossary.cli.commands.compare import compare
+from slb_glossary.cli.commands.config import config
+from slb_glossary.cli.commands.define import define
 from slb_glossary.cli.commands.install import install
+from slb_glossary.cli.commands.local import local
+from slb_glossary.cli.commands.random_term import random_term
+from slb_glossary.cli.commands.related import related
 from slb_glossary.cli.commands.search import search
+from slb_glossary.cli.commands.sync import sync
 from slb_glossary.cli.commands.terms import terms
 from slb_glossary.cli.commands.topics import topics
+from slb_glossary.cli.commands.update import update
 from slb_glossary.cli.commands.urls import urls
 
-__all__ = ["install", "search", "terms", "topics", "urls"]
+__all__ = [
+    "compare",
+    "config",
+    "define",
+    "install",
+    "local",
+    "random_term",
+    "related",
+    "search",
+    "sync",
+    "terms",
+    "update",
+    "urls",
+]

--- a/slb_glossary/cli/main.py
+++ b/slb_glossary/cli/main.py
@@ -5,7 +5,21 @@ import typing
 
 import click
 
-from slb_glossary.cli.commands import install, search, terms, topics, urls
+from slb_glossary.cli.commands import (
+    compare,
+    config,
+    define,
+    install,
+    local,
+    random_term,
+    related,
+    search,
+    sync,
+    terms,
+    topics,
+    update,
+    urls,
+)
 from slb_glossary.cli.tui import TuiUnavailableError, launch_tui
 
 __all__ = ["cli", "main"]
@@ -55,6 +69,14 @@ COMMANDS = {
     "terms": terms,
     "topics": topics,
     "urls": urls,
+    "define": define,
+    "related": related,
+    "compare": compare,
+    "random": random_term,
+    "sync": sync,
+    "update": update,
+    "local": local,
+    "config": config,
 }
 
 for name, command in COMMANDS.items():

--- a/slb_glossary/errors.py
+++ b/slb_glossary/errors.py
@@ -23,3 +23,7 @@ class ConfigError(GlossaryError):
 
 class DatabaseError(GlossaryError):
     """Raised when `slb_glossary.local` fails to open, query, or write the local database."""
+
+
+class QueryError(GlossaryError):
+    """Raised when `slb_glossary.query` can't satisfy a lookup with the source(s) it was given."""

--- a/slb_glossary/local/__init__.py
+++ b/slb_glossary/local/__init__.py
@@ -31,6 +31,7 @@ from slb_glossary.local.api import (
     get_terms_on,
     iter_term_urls,
     iter_topics,
+    random_term,
     search,
     upsert_results,
 )
@@ -38,7 +39,14 @@ from slb_glossary.local.connection import close_db, local_db, open_db
 from slb_glossary.local.loaders import load_file
 from slb_glossary.local.maintenance import flush, reset
 from slb_glossary.local.models import Database, Metadata
-from slb_glossary.local.sync import SyncSummary, sync_all, sync_query, sync_topic, sync_topics
+from slb_glossary.local.sync import (
+    SyncSummary,
+    sync_all,
+    sync_letter,
+    sync_query,
+    sync_topic,
+    sync_topics,
+)
 from slb_glossary.local.vectors import delete_vectors, upsert_vector, vector_search
 
 __all__ = [
@@ -52,6 +60,7 @@ __all__ = [
     "search",
     "get_terms_on",
     "get_term",
+    "random_term",
     "iter_term_urls",
     "iter_topics",
     "count",
@@ -65,5 +74,6 @@ __all__ = [
     "sync_topics",
     "sync_query",
     "sync_topic",
+    "sync_letter",
     "sync_all",
 ]

--- a/slb_glossary/local/api.py
+++ b/slb_glossary/local/api.py
@@ -14,6 +14,7 @@ __all__ = [
     "search",
     "get_terms_on",
     "get_term",
+    "random_term",
     "iter_term_urls",
     "iter_topics",
     "count",
@@ -233,6 +234,31 @@ async def get_term(db: Database, term_or_url: str) -> SearchResult | None:
         "SELECT * FROM terms WHERE url = ? OR term = ? COLLATE NOCASE LIMIT 1",
         (term_or_url, term_or_url),
     ) as cursor:
+        row = await cursor.fetchone()
+    return _row_to_result(row) if row is not None else None
+
+
+async def random_term(db: Database, *, topic: str | None = None) -> SearchResult | None:
+    """
+    Return one randomly chosen locally stored term, optionally restricted to a topic.
+
+    :param db: The local database to read from.
+    :param topic: Restrict the pick to this topic, or several
+        comma-separated topics. `None` picks from every locally stored term.
+    :return: A random `SearchResult`, or `None` if the local database (or
+        the given topic within it) has no terms stored yet.
+    """
+    sql = "SELECT * FROM terms"
+    params: list[typing.Any] = []
+    if topic:
+        topics = [name.strip() for name in topic.split(",") if name.strip()]
+        if topics:
+            placeholders = ", ".join("?" for _ in topics)
+            sql += f" WHERE topic COLLATE NOCASE IN ({placeholders})"
+            params.extend(topics)
+    sql += " ORDER BY RANDOM() LIMIT 1"
+
+    async with db.connection.execute(sql, params) as cursor:
         row = await cursor.fetchone()
     return _row_to_result(row) if row is not None else None
 

--- a/slb_glossary/local/sync.py
+++ b/slb_glossary/local/sync.py
@@ -10,6 +10,7 @@ import datetime
 import logging
 
 from slb_glossary.engine import get_terms_on as fetch_terms_on
+from slb_glossary.engine import iter_results_from_urls, iter_term_urls
 from slb_glossary.engine import search as live_search
 from slb_glossary.local.api import count as count_terms
 from slb_glossary.local.api import iter_topics, upsert_results
@@ -18,7 +19,14 @@ from slb_glossary.models import SearchSession
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["SyncSummary", "sync_topics", "sync_query", "sync_topic", "sync_all"]
+__all__ = [
+    "SyncSummary",
+    "sync_topics",
+    "sync_query",
+    "sync_topic",
+    "sync_letter",
+    "sync_all",
+]
 
 
 @dataclasses.dataclass(slots=True, frozen=True, kw_only=True)
@@ -130,6 +138,39 @@ async def sync_topic(
     :return: A summary of the sync.
     """
     results = fetch_terms_on(session, topic, limit=limit, concurrency=concurrency)
+    written = await upsert_results(db, results, language=session.language.value)
+    return await _record_sync(db, terms_written=written, language=session.language.value)
+
+
+async def sync_letter(
+    db: Database,
+    session: SearchSession,
+    start_letter: str,
+    *,
+    topic: str | None = None,
+    limit: int | None = None,
+    concurrency: int = 1,
+) -> SyncSummary:
+    """
+    Fetch every term starting with `start_letter` from the live glossary and store them locally.
+
+    Useful for incremental updates keyed by the alphabet instead of by
+    topic, e.g. syncing `slb-glossary update --start-letter a` through `z`
+    over several separate, spaced-out runs.
+
+    :param db: The local database to write to.
+    :param session: An open `SearchSession` to fetch from.
+    :param start_letter: The starting letter to restrict the fetch to.
+    :param topic: Also restrict the fetch to this topic, or several
+        comma-separated topics.
+    :param limit: Maximum number of terms to fetch. `None` for unlimited.
+    :param concurrency: Concurrent term-page fetches.
+    :return: A summary of the sync.
+    """
+    urls = iter_term_urls(session, topic=topic, start_letter=start_letter, limit=limit)
+    results = iter_results_from_urls(
+        session, urls, topic=topic, concurrency=concurrency, first_only=True
+    )
     written = await upsert_results(db, results, language=session.language.value)
     return await _record_sync(db, terms_written=written, language=session.language.value)
 


### PR DESCRIPTION
…ed, compare, random, sync, update, local, config), and supporting local-db sync helpers

- slb_glossary/query.py: new Source-aware query API (local/live/intelligent) with search, get_terms_on, get_term, related_terms, random_term, compare
- slb_glossary/local/api.py: add random_term
- slb_glossary/local/sync.py: add sync_letter for start-letter-scoped updates
- CLI: define, related, compare, random, sync, update, local (group: path/stats/search/get/flush/reset/sync/update), config (group: show/get/set/init/edit/wizard/path, defaults to wizard)
- CLI helpers: cli/source_options.py (--local/--live/--intelligent resolution + lazy browser session), cli/sync_options.py (shared update/sync filters)
- Wired into cli/main.py and cli/commands/__init__.py; exported query module and QueryError from slb_glossary/__init__.py

Known issue (to be fixed in a follow-up commit): `config init`/`config show`/`config set` currently error against the default TOML format because SessionConfig has None-valued fields (executable_path, proxy, viewport) that tomlkit can't serialize.